### PR TITLE
add refund button appear by status

### DIFF
--- a/src/components/BookingCardWithEdit.tsx
+++ b/src/components/BookingCardWithEdit.tsx
@@ -71,9 +71,13 @@ export default function BookingCard2({
                     Edit
                 </Button>
 
-                <Button variant="contained" color="success" onClick={handleRefund}>
-                    Refund
-                </Button>
+                { 
+                    bookingData.status !== "canceled" ? 
+                        <Button variant="contained" color="success" onClick={handleRefund}>
+                            Refund
+                        </Button>
+                    : ""
+                }
 
                 {/* Delete Button */}
                 <Button variant="contained" color="error" onClick={handleDelete}>


### PR DESCRIPTION
This pull request introduces a conditional rendering update to the `BookingCardWithEdit` component. The change ensures that the "Refund" button is only displayed when the booking status is not "canceled."

* **Conditional Rendering for Refund Button**:
  - In `src/components/BookingCardWithEdit.tsx`, the "Refund" button is now conditionally rendered based on the `bookingData.status`. It will only be displayed if the status is not "canceled."