### PR TITLE
fix: update hover styles for Sign-In / Register link in NavBar component

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -50,7 +50,7 @@ export default async function NavBar() {
                     ) : (
                         <Link
                             href="/signin"
-                            className="border p-2 rounded-lg text-black font-sans font-semibold hover:bg-blue-300 hover:text-black whitespace-nowrap"
+                            className="border p-2 rounded-lg text-black font-sans font-semibold hover:bg-black hover:text-white whitespace-nowrap"
                         >
                             Sign-In / Register
                         </Link>


### PR DESCRIPTION
This pull request makes a small styling update to the `NavBar` component. The hover state for the "Sign-In / Register" button has been updated to change the background to black and the text to white instead of using a blue background with black text. (`src/components/NavBar.tsx`, [src/components/NavBar.tsxL53-R53](diffhunk://#diff-ed889d51bb93237b769c975b1bffc17df06a762fe033cc6be6c417156f29df8fL53-R53))